### PR TITLE
chore: remove public mods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/cryptlex/lexactivator-rust"
 # TODO
 # documentation = "https://docs.cryptlex.com/node-locked-licenses/using-lexactivator-with-rust"
 license = "MIT"
-include = ["/libs/**/*.a", "/libs/**/*.lib", "/libs/**/*.dll"]
-
+include = ["/libs/**/*.a", "/libs/**/*.lib", "/libs/**/*.dll", "src/**/*"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,14 @@ repository = "https://github.com/cryptlex/lexactivator-rust"
 # TODO
 # documentation = "https://docs.cryptlex.com/node-locked-licenses/using-lexactivator-with-rust"
 license = "MIT"
-include = ["/libs/**/*.a", "/libs/**/*.lib", "/libs/**/*.dll", "src/**/*"]
+include = [
+    "build.rs",
+    "/src",
+    "/examples",
+    "/libs/**/*.a",
+    "/libs/**/*.lib",
+    "/libs/**/*.dll",
+]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -18,5 +25,5 @@ serde_json = "1.0"
 cfg-if = "1.0.0"
 
 [[example]]
-name="license-activation"
-crate-type=["bin"]
+name = "license-activation"
+crate-type = ["bin"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
 use std::ffi::*;
 use serde::Deserialize;
 
-pub use extern_functions::*;
-pub use error_codes::*;
-pub use string_utils::*;
+mod extern_functions;
+use extern_functions::*;
 
-pub mod extern_functions;
 pub mod error_codes;
-pub mod string_utils;
+pub use error_codes::*;
+
+mod string_utils;
+use string_utils::*;
+
 
 
 /// Represents a license meter attribute.


### PR DESCRIPTION
1. Internal FFI calls were public. They have been made private.
2. Internal string helpers were public. They have been made private.
3. Update include prop in Cargo.toml to include source and build scripts